### PR TITLE
fix: correct mismatch variable name

### DIFF
--- a/bitnami/mastodon/4/debian-11/rootfs/opt/bitnami/scripts/libmastodon.sh
+++ b/bitnami/mastodon/4/debian-11/rootfs/opt/bitnami/scripts/libmastodon.sh
@@ -113,7 +113,7 @@ mastodon_validate() {
         check_empty_value "MASTODON_S3_HOSTNAME"
         check_resolved_hostname "$MASTODON_S3_HOSTNAME"
         check_valid_port "MASTODON_S3_PORT_NUMBER"
-        check_empty_value "MASTODON_S3_ALIAS"
+        check_empty_value "MASTODON_S3_ALIAS_HOST"
         check_empty_value "MASTODON_S3_ENDPOINT"
         check_empty_value "MASTODON_AWS_ACCESS_KEY_ID"
         check_empty_value "MASTODON_AWS_SECRET_ACCESS_KEY"


### PR DESCRIPTION
"MASTODON_S3_ALIAS" is not matched the definition in mastodon-env.sh

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Match the variable name in `mastodon-env.sh` and `libmastodon.sh`.

### Benefits

<!-- What benefits will be realized by the code change? -->

Correct the variable name to get rid of the `unbound value` issue.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

If set `S3_ENABLED` to `true`, because of the mismatched variable name, there's an `unbound value` error.

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
